### PR TITLE
Change to minimal docker image instead of larger fixture examples

### DIFF
--- a/test/fixtures/files/docker_compose/Dockerfile
+++ b/test/fixtures/files/docker_compose/Dockerfile
@@ -1,0 +1,3 @@
+FROM alpine:3.7
+
+CMD ["sleep", "30"]

--- a/test/fixtures/files/docker_compose/no_ports.yml
+++ b/test/fixtures/files/docker_compose/no_ports.yml
@@ -2,7 +2,7 @@ version: '3.3'
 
 services:
   postgres:
-    image: postgres:9.6-alpine
+    build: .
     environment:
       POSTGRES_DB: example_app
       POSTGRES_PASSWORD: password

--- a/test/fixtures/files/docker_compose/udp_only_service.yml
+++ b/test/fixtures/files/docker_compose/udp_only_service.yml
@@ -2,7 +2,7 @@ version: '3.3'
 
 services:
   postgres:
-    image: postgres:9.6-alpine
+    build: .
     environment:
       POSTGRES_DB: example_app
       POSTGRES_PASSWORD: password

--- a/test/fixtures/files/docker_compose/v1.yml
+++ b/test/fixtures/files/docker_compose/v1.yml
@@ -1,6 +1,6 @@
 services:
   converter:
-    image: zrrrzzt/docker-unoconv-webservice:4.7.3
+    build: .
     network_mode: bridge
     ports:
     - 3000/tcp
@@ -9,7 +9,7 @@ services:
     environment:
       MYSQL_DATABASE: example_app
       MYSQL_ROOT_PASSWORD: password
-    image: mysql:8
+    build: .
     network_mode: bridge
     ports:
     - 3306/tcp
@@ -17,7 +17,7 @@ services:
     environment:
       POSTGRES_DB: example_app
       POSTGRES_PASSWORD: password
-    image: postgres:9.6-alpine
+    build: .
     network_mode: bridge
     ports:
     - 5432/tcp

--- a/test/fixtures/files/docker_compose/v2.1.yml
+++ b/test/fixtures/files/docker_compose/v2.1.yml
@@ -1,6 +1,6 @@
 services:
   converter:
-    image: zrrrzzt/docker-unoconv-webservice:4.7.3
+    build: .
     ports:
     - 3000/tcp
     - 6060/udp
@@ -8,14 +8,14 @@ services:
     environment:
       MYSQL_DATABASE: example_app
       MYSQL_ROOT_PASSWORD: password
-    image: mysql:8
+    build: .
     ports:
     - 3306/tcp
   postgres:
     environment:
       POSTGRES_DB: example_app
       POSTGRES_PASSWORD: password
-    image: postgres:9.6-alpine
+    build: .
     ports:
     - 5432/tcp
 version: '2.1'

--- a/test/fixtures/files/docker_compose/v2.2.yml
+++ b/test/fixtures/files/docker_compose/v2.2.yml
@@ -1,6 +1,6 @@
 services:
   converter:
-    image: zrrrzzt/docker-unoconv-webservice:4.7.3
+    build: .
     ports:
     - 3000/tcp
     - 6060/udp
@@ -8,14 +8,14 @@ services:
     environment:
       MYSQL_DATABASE: example_app
       MYSQL_ROOT_PASSWORD: password
-    image: mysql:8
+    build: .
     ports:
     - 3306/tcp
   postgres:
     environment:
       POSTGRES_DB: example_app
       POSTGRES_PASSWORD: password
-    image: postgres:9.6-alpine
+    build: .
     ports:
     - 5432/tcp
 version: '2.2'

--- a/test/fixtures/files/docker_compose/v2.yml
+++ b/test/fixtures/files/docker_compose/v2.yml
@@ -1,6 +1,6 @@
 services:
   converter:
-    image: zrrrzzt/docker-unoconv-webservice:4.7.3
+    build: .
     ports:
     - 3000/tcp
     - 6060/udp
@@ -8,14 +8,14 @@ services:
     environment:
       MYSQL_DATABASE: example_app
       MYSQL_ROOT_PASSWORD: password
-    image: mysql:8
+    build: .
     ports:
     - 3306/tcp
   postgres:
     environment:
       POSTGRES_DB: example_app
       POSTGRES_PASSWORD: password
-    image: postgres:9.6-alpine
+    build: .
     ports:
     - 5432/tcp
 version: '2.0'

--- a/test/fixtures/files/docker_compose/v3.1.yml
+++ b/test/fixtures/files/docker_compose/v3.1.yml
@@ -1,6 +1,6 @@
 services:
   converter:
-    image: zrrrzzt/docker-unoconv-webservice:4.7.3
+    build: .
     ports:
     - 3000/tcp
     - 6060/udp
@@ -8,14 +8,14 @@ services:
     environment:
       MYSQL_DATABASE: example_app
       MYSQL_ROOT_PASSWORD: password
-    image: mysql:8
+    build: .
     ports:
     - 3306/tcp
   postgres:
     environment:
       POSTGRES_DB: example_app
       POSTGRES_PASSWORD: password
-    image: postgres:9.6-alpine
+    build: .
     ports:
     - 5432/tcp
 version: '3.1'

--- a/test/fixtures/files/docker_compose/v3.2.yml
+++ b/test/fixtures/files/docker_compose/v3.2.yml
@@ -1,6 +1,6 @@
 services:
   converter:
-    image: zrrrzzt/docker-unoconv-webservice:4.7.3
+    build: .
     ports:
     - target: 3000
     - protocol: udp
@@ -9,14 +9,14 @@ services:
     environment:
       MYSQL_DATABASE: example_app
       MYSQL_ROOT_PASSWORD: password
-    image: mysql:8
+    build: .
     ports:
     - target: 3306
   postgres:
     environment:
       POSTGRES_DB: example_app
       POSTGRES_PASSWORD: password
-    image: postgres:9.6-alpine
+    build: .
     ports:
     - target: 5432
 version: '3.2'

--- a/test/fixtures/files/docker_compose/v3.3.yml
+++ b/test/fixtures/files/docker_compose/v3.3.yml
@@ -2,13 +2,13 @@ version: '3.3'
 
 services:
   converter:
-    image: zrrrzzt/docker-unoconv-webservice:4.7.3
+    build: .
     ports:
       - "3000"
       - "6060/udp"
 
   mysql:
-    image: mysql:8
+    build: .
     environment:
       MYSQL_DATABASE: example_app
       MYSQL_ROOT_PASSWORD: password
@@ -16,7 +16,7 @@ services:
       - "3306"
 
   postgres:
-    image: postgres:9.6-alpine
+    build: .
     environment:
       POSTGRES_DB: example_app
       POSTGRES_PASSWORD: password

--- a/test/fixtures/files/docker_compose/v3.yml
+++ b/test/fixtures/files/docker_compose/v3.yml
@@ -1,6 +1,6 @@
 services:
   converter:
-    image: zrrrzzt/docker-unoconv-webservice:4.7.3
+    build: .
     ports:
     - 3000/tcp
     - 6060/udp
@@ -8,14 +8,14 @@ services:
     environment:
       MYSQL_DATABASE: example_app
       MYSQL_ROOT_PASSWORD: password
-    image: mysql:8
+    build: .
     ports:
     - 3306/tcp
   postgres:
     environment:
       POSTGRES_DB: example_app
       POSTGRES_PASSWORD: password
-    image: postgres:9.6-alpine
+    build: .
     ports:
     - 5432/tcp
 version: '3.0'

--- a/test/support/docker_compose_helpers.rb
+++ b/test/support/docker_compose_helpers.rb
@@ -21,7 +21,7 @@ module DockerComposeHelpers
   end
 
   def self.up(config_file)
-    command = "docker-compose --file=#{config_file} up --remove-orphans -d"
+    command = "docker-compose --file=#{config_file} up --build --remove-orphans -d"
     output, status = Open3.capture2e(command)
     print output, "\n" unless status.success?
   end


### PR DESCRIPTION
There's not really a need to use real images in our tests (as far as I can tell). To make running the tests faster if base images are not already downloaded, I changed the test fixtures to build a minimal image that is referenced in the test fixture compose files.